### PR TITLE
Fix/#4 device uid

### DIFF
--- a/assets/icons/_index.ts
+++ b/assets/icons/_index.ts
@@ -2,7 +2,7 @@ import BackIcon from "./Back.svg";
 import CloseIcon from "./circle_close.svg";
 import InfoIcon from "./info.svg";
 import LogoIcon from "./logo.svg";
-import MenuIcon from "./menu.svg";
+import MenuIcon from "./Menu.svg";
 import MoveFileIcon from "./moveFile.svg";
 import SearchIcon from "./search.svg";
 import TrashIcon from "./trash.svg";


### PR DESCRIPTION
## 🎟️ 관련 이슈

Closes #4 

## 👩‍💻 구현 내용

android:usesCleartextTraffic="true" 제거

networkSecurityConfig 속성 제거

res/xml/network_security_config.xml 삭제

## 💬 코멘트

기존 HTTP 서버 사용으로 인해 Android 9(API 28)+ 이상에서 발생하는 보안 제한을 우회하기 위해 usesCleartextTraffic 및 network_security_config.xml 설정을 적용했었음.

서버에 SSL 인증서 적용 완료 후, HTTP 우회 설정을 모두 제거하고 HTTPS 통신 기반으로 전환함.

설정 정리 후 APK 재빌드 및 배포하여 테스트한 결과, 기존에 특정 기기에서 발생하던 오류가 더 이상 발생하지 않음을 확인함.